### PR TITLE
Add implicit conversions to DependencyProvider<TDependency>

### DIFF
--- a/SparkyTools.DependencyProvider.UnitTests/DependencyProviderTests.cs
+++ b/SparkyTools.DependencyProvider.UnitTests/DependencyProviderTests.cs
@@ -9,6 +9,19 @@ namespace SparkyTools.DependencyProvider.UnitTests
     [TestClass]
     public class DependencyProviderTests
     {
+        class Consumer
+        {
+            private readonly DependencyProvider<string> valueProvider;
+
+            /// <inheritdoc />
+            public Consumer(DependencyProvider<string> valueProvider)
+            {
+                this.valueProvider = valueProvider;
+            }
+
+            public string Value => valueProvider.GetValue();
+        }
+        
         [TestMethod]
         public void DependencyProvider_should_work_when_created_via_function_constructor()
         {
@@ -80,6 +93,41 @@ namespace SparkyTools.DependencyProvider.UnitTests
             });
         }
 
+        [TestMethod]
+        public void DependencyProvider_created_with_implicit_conversion_should_have_converted_value()
+        {
+            DependencyProvider<decimal> provider = 56m;
+            
+            Assert.AreEqual(56m, provider.GetValue());
+        }
+        
+        
+        [TestMethod]
+        public void DependencyProvider_created_with_implicit_conversion_from_func_should_have_converted_value()
+        {
+            var callCount = 0;
+            Func<float> factory = () =>
+            {
+                ++callCount;
+                return 42f;
+            };
+
+            DependencyProvider<float> provider = factory;
+            
+            Assert.AreEqual(42f, provider.GetValue());
+            Assert.AreEqual(1, callCount);
+            
+        }
+        
+        
+        [TestMethod]
+        public void DependencyProvider_consumber_created_with_implicit_conversion_should_have_converted_value()
+        {
+            var consumer = new Consumer("test");
+            
+            Assert.AreEqual("test", consumer.Value);
+        }
+        
         [TestMethod]
         public void InvalidOperationException_should_be_thrown_if_Static_is_called_after_GetValue()
         {

--- a/SparkyTools.DependencyProvider/DependencyProvider.cs
+++ b/SparkyTools.DependencyProvider/DependencyProvider.cs
@@ -141,5 +141,30 @@ namespace SparkyTools.DependencyProvider
 
             return value;
         }
+
+        /// <summary>
+        /// Creates a Static <see cref="DependencyProvider{TDependency}"/> that returns <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value the created <see cref="DependencyProvider{TDependency}"/> should return</param>
+        /// <returns>a <see cref="DependencyProvider{TDependency}"/> that returns <paramref name="value"/></returns>
+        public static implicit operator DependencyProvider<TDependency>(TDependency value)
+        {
+            return new DependencyProvider<TDependency>(value);
+        }
+        
+        /// <summary>
+        /// Creates a Static <see cref="DependencyProvider{TDependency}"/> that returns
+        /// a value from <paramref name="factory"/>
+        /// </summary>
+        /// <param name="factory">
+        /// The function to call to provide the value for the created <see cref="DependencyProvider{TDependency}"/>
+        /// </param>
+        /// <returns>
+        /// a <see cref="DependencyProvider{TDependency}"/> that returns values from <paramref name="factory"/>
+        /// </returns>
+        public static implicit operator DependencyProvider<TDependency>(Func<TDependency> factory)
+        {
+            return new DependencyProvider<TDependency>(factory);
+        }
     }
 }

--- a/SparkyTools.DependencyProvider/SparkyTools.DependencyProvider.csproj
+++ b/SparkyTools.DependencyProvider/SparkyTools.DependencyProvider.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,13 +12,13 @@
     <RepositoryUrl>https://github.com/BrianSchroer/SparkyTools</RepositoryUrl>
     <PackageTags>test, testing, unittest, unittesting, dependencyinjection</PackageTags>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.0\SparkyTools.DependencyProvider.xml</DocumentationFile>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DocumentationFile>bin\Debug\netstandard1.0\SparkyTools.DependencyProvider.xml</DocumentationFile>
+  </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="$(SolutionDir)MarkdownDocNet.exe $(TargetDir)$(TargetName).xml $(TargetDir)$(TargetName)$(TargetExt) $(TargetDir)$(TargetName).md" />
   </Target>
-
 </Project>

--- a/SparkyTools.DependencyProvider/api.md
+++ b/SparkyTools.DependencyProvider/api.md
@@ -49,6 +49,16 @@ A DependencyProvider instance can be created:
     var realTimeProvider = DependencyProvider.Create(DateTime.Now);
     var fakeTimeProvider = DependencyProvider.Create(DateTime.Parse("4/20/2018 4:20 PM"));
     ```
+* via *implicit conversion*
+    ```csharp
+    DependencyProvider<DateTime> fakeTimeProvider = new DateTime(2018, 1, 4);
+    //C# is a bit less fluent about chained implicit conversions...  
+    DependencyProvider<DateTime> readTimeProvider = () => DateTime.Now(); 
+    
+    //most helpful when passing dependencies
+    var foo = new Foo(new DateTime(2018, 1, 4));
+    var fooRealtime = new Foo(() => DateTime.Now())
+    ```
 
 The *DependencyProvider*.**Static()** method tells the provider to cache the first value
 returned by **GetValue()** and return that same value for all subsequent calls:


### PR DESCRIPTION
This change allows you to write code like

```csharp
var foo = new Foo(new DateTime(2018, 8, 3));
```

rather than having to use the static creators or constructors.